### PR TITLE
Add start date/time availability config

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -190,10 +190,12 @@
     .then(r => r.json())
     .then(json => {
       availability = json;
-      dateEl.min = availability.start_date;
+      const today = new Date().toISOString().split('T')[0];
+      dateEl.min = availability.start_date || today;
       dateEl.max = availability.end_date;
       timeEl.min = availability.start_time;
       timeEl.max = availability.end_time;
+      updateTimeLimits();
     })
     .catch(err => console.error('Errore caricamento disponibilità', err));
 
@@ -202,6 +204,41 @@
       selectEl.innerHTML = `<option value="">${placeholder}</option>`;
       items.forEach(val => selectEl.appendChild(new Option(val, val)));
       selectEl.disabled = false;
+    }
+
+    function updateTimeLimits() {
+      const date = dateEl.value;
+      if (!date) return;
+      if (availability.closed_dates && availability.closed_dates.includes(date)) {
+        timeEl.disabled = true;
+        timeEl.value = '';
+        return;
+      }
+      timeEl.disabled = false;
+
+      const day = new Date(date).getDay();
+      let min = availability.start_time;
+      let max = availability.end_time;
+
+      if (availability.days && availability.days[day]) {
+        const info = availability.days[day];
+        min = info.start_time || min;
+        max = info.end_time || max;
+      }
+
+      timeEl.min = min;
+      timeEl.max = max;
+
+      const today = new Date().toISOString().split('T')[0];
+      let defaultTime = min;
+      if (date === today) {
+        const now = new Date();
+        now.setHours(now.getHours() + 1);
+        defaultTime = now.toISOString().slice(11,16);
+        if (defaultTime < min) defaultTime = min;
+        if (defaultTime > max) defaultTime = max;
+      }
+      timeEl.value = defaultTime;
     }
 
     // Cambio lingua
@@ -214,7 +251,10 @@
     document.addEventListener('DOMContentLoaded', () => {
       langSelect.value = 'it';
       langSelect.dispatchEvent(new Event('change'));
+      updateTimeLimits();
     });
+
+    dateEl.addEventListener('change', updateTimeLimits);
 
     // Dropdown logic
     modelloEl.addEventListener('change', () => {

--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ This repository contains a simple valuation and appointment booking form.
 
 ## Booking Availability
 
-The `availability.json` file defines the date and time range that users can
-select when booking an appointment. It contains four fields:
+The `availability.json` file controls which dates and times can be selected.
+It supports the following keys:
 
-- `start_date`: first selectable day (ISO `YYYY-MM-DD`)
-- `end_date`: last selectable day (ISO `YYYY-MM-DD`)
-- `start_time`: earliest selectable time (24h `HH:MM`)
-- `end_time`: latest selectable time (24h `HH:MM`)
+- `start_date` (optional): first selectable day. If omitted, today's date is used.
+- `end_date`: last selectable day.
+- `start_time` (optional): default opening time used when no day specific hours are provided.
+- `end_time`: default closing time.
+- `days` (optional): object mapping weekday numbers (`0` = Sunday .. `6` = Saturday)
+  to objects containing `start_time` and/or `end_time` that override the defaults.
+- `closed_dates` (optional): array of ISO dates that cannot be booked.
 
-Update these values to adjust the booking window shown in the form.
+`start_date` and `end_date` always limit the selectable range. When a date falls
+into `closed_dates` the time field is disabled. For other dates, the hours
+specified for that weekday in `days` take precedence; otherwise the `start_time`
+and `end_time` values are used.

--- a/availability.json
+++ b/availability.json
@@ -2,5 +2,10 @@
   "start_date": "2025-07-25",
   "end_date": "2025-12-31",
   "start_time": "09:00",
-  "end_time": "18:00"
+  "end_time": "18:00",
+  "days": {
+    "6": {"start_time": "10:00", "end_time": "14:00"},
+    "0": {"start_time": "10:00", "end_time": "16:00"}
+  },
+  "closed_dates": ["2025-08-15"]
 }


### PR DESCRIPTION
## Summary
- extend `availability.json` with optional weekday overrides
- explain new availability options in README
- handle optional `start_date` and `start_time` when loading availability
- add `updateTimeLimits()` to set time constraints per day and default time one hour ahead

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887f9056f808328ad48165fabb90836